### PR TITLE
Add missing Options to help file

### DIFF
--- a/lib/help
+++ b/lib/help
@@ -9,7 +9,6 @@ Usage: $(basename "$0") [options]
 
 Options:
     -h, --help      Print this help text
-    -l, --list      Print a list of additional software to install
     --no-packages   Suppress package updates
     --no-sync       Suppress pulling from the remote repository
     --no-macos      Suppress applying custom macOS system preferences

--- a/lib/help
+++ b/lib/help
@@ -12,6 +12,8 @@ Options:
     -l, --list      Print a list of additional software to install
     --no-packages   Suppress package updates
     --no-sync       Suppress pulling from the remote repository
+    --no-macos      Suppress applying custom macOS system preferences
+    --with-apps     Install optional macOS GUI Applications    
 
 Documentation can be found at https://github.com/codfish/dotfiles/
 

--- a/lib/list_apps
+++ b/lib/list_apps
@@ -1,6 +1,6 @@
 #!/usr/bin/env zsh
 
-run_list() {
+run_list_apps() {
 
 cat <<EOT
 macOS dotfiles - Chris O'Donnell - http://codfish.io/


### PR DESCRIPTION
--no-macos and --with-apps were not listed in the help file despite being available options